### PR TITLE
AVX-55377: ensure pytest exits nonzero for result publishing failure

### DIFF
--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -699,6 +699,11 @@ class PyTestRailPlugin(object):
                 )
             )
 
+            # Exit with a nonzero exit code to express that an error occurred
+            # during results publishing. The GitHub Actions runners need to be
+            # aware of it.
+            session.exitcode = pytest.ExitCode.INTERNAL_ERROR
+
     def create_test_run(
         self,
         assign_user_id,


### PR DESCRIPTION
We need to make sure we exit with a nonzero exit code when we fail to publish any results to TestRail. This is especially important for the GitHub Actions runners which pay attention to exit codes.