### PR TITLE
AVX-55377: add missing dependency on jira

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 pytest==3.1.2
 requests==2.20.0
 simplejson==3.11.1
+jira==3.8.0

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     install_requires=[
         "pytest>=3.6",
         "requests>=2.20.0",
+        "jira>=3.8.0",
     ],
     include_package_data=True,
     entry_points={"pytest11": ["pytest-testrail = pytest_testrail.conftest"]},


### PR DESCRIPTION
Whatever depends on this module should automatically be able to pick up its dependencies, including the jira plugin.